### PR TITLE
changes for puppet-lint and added new package providers

### DIFF
--- a/puppet/pivotal-tcserver/manifests/init.pp
+++ b/puppet/pivotal-tcserver/manifests/init.pp
@@ -61,7 +61,7 @@ class tcserver (
   }
 
   class {'tcserver::install':
-    version => $package_ensure
+    version  => $package_ensure,
   } ->
   class {'tcserver::postinstall':
     ensure         => $package_ensure,

--- a/puppet/pivotal-tcserver/manifests/instance.pp
+++ b/puppet/pivotal-tcserver/manifests/instance.pp
@@ -109,43 +109,43 @@ define tcserver::instance (
     }
 
     file { "${cwd}/${name}":
-      ensure      => directory,
-      owner       => $tcserver_user,
-      group       => $tcserver_group,
-      recurse     => true,
-      ignore      => "${cwd}/${name}/${apps_dir}",
-      require     => Tcruntime_instance[$name]
+      ensure  => directory,
+      owner   => $tcserver_user,
+      group   => $tcserver_group,
+      recurse => true,
+      ignore  => "${cwd}/${name}/${apps_dir}",
+      require => Tcruntime_instance[$name]
     }
 
     file { "/etc/init.d/tcserver-instance-${name}":
-      ensure      => link,
-      target      => "${cwd}/${name}/bin/init.d.sh",
+      ensure => link,
+      target => "${cwd}/${name}/bin/init.d.sh",
     }
 
     tcserver::service {$name:
-      ensure      => $ensure,
-      name        => $name,
-      cwd         => $cwd,
+      ensure => $ensure,
+      name   => $name,
+      cwd    => $cwd,
     }
 
     if $deploy_apps {
       file { "${cwd}/${name}/${apps_dir}":
-        recurse   => true,
-        source    => $apps_source
+        recurse => true,
+        source  => $apps_source
       }
     }
   } else {
     tcserver::service {$name:
-      ensure      => absent,
-      name        => $name,
-      cwd         => $cwd,
+      ensure => absent,
+      name   => $name,
+      cwd    => $cwd,
     }->
     file { "${cwd}/${name}":
-      ensure      => absent,
-      force       => true
+      ensure => absent,
+      force  => true
     }->
     file { "/etc/init.d/tcserver-instance-${name}":
-      ensure      => absent,
+      ensure => absent,
     }
   }
 }

--- a/puppet/pivotal-tcserver/manifests/service.pp
+++ b/puppet/pivotal-tcserver/manifests/service.pp
@@ -24,14 +24,14 @@ define tcserver::service (
 ) {
   if $ensure == absent {
     service { "tcserver-instance-${name}":
-      ensure    => stopped,
-      status    => "ps -p `cat ${cwd}/${name}/logs/tcserver.pid` > /dev/null 2>&1",
+      ensure => stopped,
+      status => "ps -p `cat ${cwd}/${name}/logs/tcserver.pid` > /dev/null 2>&1",
     }
   } else {
     service { "tcserver-instance-${name}":
-      ensure    => $ensure,
-      status    => "ps -p `cat ${cwd}/${name}/logs/tcserver.pid` > /dev/null 2>&1",
-      require   => File["${cwd}/${name}"]
+      ensure  => $ensure,
+      status  => "ps -p `cat ${cwd}/${name}/logs/tcserver.pid` > /dev/null 2>&1",
+      require => File["${cwd}/${name}"]
     }
   }
 }


### PR DESCRIPTION
This change is to allow users of this module that have hosts no able to access the internet, and do not want to mirror your pivotal repository.  It adds an rpm, dpkg, zypper, and yum provider the package.  rpm and dpkg download the package from the puppet master, and zypper and yum use configured host repositories.

I have also removed some spaces on hash-rocket lines.  This is just best practice based on puppet-lint. 

Any questions or comments welcome.
